### PR TITLE
Update README.md - 강의 시점의 코드 찾아가는 방법 안내를 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Spring Boot
 
 *  https://project-board-uno.herokuapp.com/
 
+## 강의 찾아가기
+
+게시판 서비스는 강의와 공부 목적으로 만들어진 프로젝트입니다.
+따라서 강의의 어떤 시점으로든 코드를 찾아가서 쉽게 관찰할 수 있도록 되어 있습니다.
+특정 강의 시점의 소스코드를 좀 더 편리하게 확인하고 싶다면 릴리즈 탭을 확인해 보세요.
+
+* https://github.com/djkeh/fastcampus-project-board/releases
+
 ## 질문, 건의
 
 프로젝트에 관해 궁금하신 점이나 건의 사항이 있으시다면 아래 항목을 이용해 주세요.


### PR DESCRIPTION
수강생들이 github 사용법에 아직 익숙치 않기 때문에
특정 강의의 시점으로 돌아가서 코드를 보는 것에 어려움을 겪고 문의를 하기도 한다.
이를 해소하고자 방법을 안내하기로 한다.

모든 pull request 들이 매 강의를 기준으로 작성되었기 때문에,
release note 를 본다면 보고있는 강의 위치의 변경점을 따로 확인할 수 있고,
그 위치로 브랜치를 check out 하여 소스코드를 다운로드 받을 수도 있다.
이를 `README.md` 문서에서 이와 같이 안내한다.