### PR TITLE
[테스트 데이터 생성기] CH 01. CLIP 07 - 단위 테스트 실습

### DIFF
--- a/src/test/java/com/fastcampus/projectboard/repository/HashtagRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboard/repository/HashtagRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.fastcampus.projectboard.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
+
+import javax.persistence.EntityNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+@DisplayName("[Repository] 해시태그 테스트")
+@DataJpaTest
+class HashtagRepositoryTest {
+
+    @Autowired private HashtagRepository sut;
+
+    @DisplayName("해시태그가 없으면, 예외를 던진다.")
+    @Test
+    void givenHashtagId_whenHashTagDoesNotExist_thenThrowsException() {
+        // Given
+        Long hashtagId = 1L;
+        sut.deleteById(hashtagId);
+
+        // When
+        Throwable t = catchThrowable(() -> sut.getReferenceById(hashtagId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(JpaObjectRetrievalFailureException.class)
+                .hasRootCauseInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
@@ -18,8 +18,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 
 @DisplayName("비즈니스 로직 - 해시태그")
 @ExtendWith(MockitoExtension.class)
@@ -103,4 +102,20 @@ class HashtagServiceTest {
         then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
     }
 
+    @DisplayName("연관된 게시글이 없는 해시태그 ID가 주어지면, 해시태그를 삭제한다.")
+    @Test
+    void givenHashtagId_whenDeletingHashtagWithoutRelevantArticle_thenDeletesHashtagOnly() {
+        // Given
+        Long hashtagId = 1L;
+        Hashtag hashtag = Hashtag.of("java");
+        given(hashtagRepository.getReferenceById(hashtagId)).willReturn(hashtag);
+        willDoNothing().given(hashtagRepository).delete(hashtag);
+
+        // When
+        sut.deleteHashtagWithoutArticles(hashtagId);
+
+        // Then
+        then(hashtagRepository).should().getReferenceById(hashtagId);
+        then(hashtagRepository).should().delete(hashtag);
+    }
 }

--- a/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
@@ -14,11 +14,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.BDDMockito.*;
 
@@ -136,5 +138,20 @@ class HashtagServiceTest {
         // Then
         then(hashtagRepository).should().getReferenceById(hashtagId);
         then(hashtagRepository).should(times(0)).delete(hashtag);
+    }
+
+    @DisplayName("존재하지 않는 해시태그 ID가 주어지면, 예외를 던진다.")
+    @Test
+    void givenNonexistentHashtagId_whenDeleting_thenThrowsException() {
+        // Given
+        Long hashtagId = -123L;
+        given(hashtagRepository.getReferenceById(hashtagId)).willThrow(RuntimeException.class);
+
+        // When
+        Throwable t = catchThrowable(() -> sut.deleteHashtagWithoutArticles(hashtagId));
+
+        // Then
+        assertThat(t).isInstanceOf(RuntimeException.class);
+        then(hashtagRepository).should().getReferenceById(hashtagId);
     }
 }

--- a/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/HashtagServiceTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboard.service;
 
+import com.fastcampus.projectboard.domain.Article;
 import com.fastcampus.projectboard.domain.Hashtag;
 import com.fastcampus.projectboard.repository.HashtagRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Set;
@@ -117,5 +119,22 @@ class HashtagServiceTest {
         // Then
         then(hashtagRepository).should().getReferenceById(hashtagId);
         then(hashtagRepository).should().delete(hashtag);
+    }
+
+    @DisplayName("연관된 게시글이 있는 해시태그 ID가 주어지면, 해시태그를 삭제하지 않는다.")
+    @Test
+    void givenHashtagId_whenDeletingHashtagWithRelevantArticle_thenDoesNotDeleteHashtag() {
+        // Given
+        Long hashtagId = 1L;
+        Hashtag hashtag = Hashtag.of("java");
+        ReflectionTestUtils.setField(hashtag, "articles", Set.of(Article.of(null, null, null)));
+        given(hashtagRepository.getReferenceById(hashtagId)).willReturn(hashtag);
+
+        // When
+        sut.deleteHashtagWithoutArticles(hashtagId);
+
+        // Then
+        then(hashtagRepository).should().getReferenceById(hashtagId);
+        then(hashtagRepository).should(times(0)).delete(hashtag);
     }
 }


### PR DESCRIPTION
이 작업은 단위 테스트를 연습하고자 하는 과정 중에서, 테스트 커버리지를 관찰하던 중 비어있던 해시태그 서비스의 테스트를 추가합니다.

This closes #144 